### PR TITLE
Add support for YAML (and JSON) config

### DIFF
--- a/cloudprober/templates/configmap.yaml
+++ b/cloudprober/templates/configmap.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ include "cloudprober.fullname" . }}
 data:
-  cloudprober.cfg: |
+  cloudprober.{{- .Values.config.format }}: |
   {{- .Values.config | nindent 4}}
   {{ range .Values.additionalConfigs }}
   {{.name }}: |

--- a/cloudprober/templates/configmap.yaml
+++ b/cloudprober/templates/configmap.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ include "cloudprober.fullname" . }}
 data:
-  cloudprober.{{- .Values.config.format }}: |
+  cloudprober.{{- .Values.configFormat }}: |
   {{- .Values.config | nindent 4}}
   {{ range .Values.additionalConfigs }}
   {{.name }}: |

--- a/cloudprober/templates/deployment.yaml
+++ b/cloudprober/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          args: ['--config_file', '/cfg/cloudprober.{{- .Values.config.format -}}', '--logtostderr']
+          args: ['--config_file', '/cfg/cloudprober.{{- .Values.configFormat -}}', '--logtostderr']
           volumeMounts:
             - name: cloudprober-config
               mountPath: /cfg

--- a/cloudprober/templates/deployment.yaml
+++ b/cloudprober/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          args: ['--config_file', '/cfg/cloudprober.cfg', '--logtostderr']
+          args: ['--config_file', '/cfg/cloudprober.{{- .Values.config.format -}}', '--logtostderr']
           volumeMounts:
             - name: cloudprober-config
               mountPath: /cfg

--- a/cloudprober/values.yaml
+++ b/cloudprober/values.yaml
@@ -20,6 +20,9 @@ image:
 configMap:
   name: ''
   create: true
+  # The config file suffix; supported suffixes are in
+  # https://github.com/cloudprober/cloudprober/blob/master/config/config.go#L72
+  format: 'cfg'
 
 # You can either embed config here, or keep it in a separate file and provide
 # it at run-time, like this:

--- a/cloudprober/values.yaml
+++ b/cloudprober/values.yaml
@@ -20,9 +20,10 @@ image:
 configMap:
   name: ''
   create: true
-  # The config file suffix; supported suffixes are in
-  # https://github.com/cloudprober/cloudprober/blob/master/config/config.go#L72
-  format: 'cfg'
+
+# The config file suffix; suffixes that provide different parsing are:
+# "json", "yaml", "yml"
+configFormat: 'cfg'
 
 # You can either embed config here, or keep it in a separate file and provide
 # it at run-time, like this:


### PR DESCRIPTION
I was looking to adopt CloudProber and wrote a bunch of YAML config (because the rest of my team is more familiar with it), and then realized that the helm chart only supports textproto.
