### PR TITLE
Add configFileName templating, to provide additional controls for externally managed configMaps

### DIFF
--- a/cloudprober/templates/configmap.yaml
+++ b/cloudprober/templates/configmap.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ include "cloudprober.fullname" . }}
 data:
-  {{- .Values.configFileName | default "cloudprober" }}.{{- .Values.configFormat }}: |
+  {{- .Values.configFileName }}.{{- .Values.configFormat }}: |
   {{- .Values.config | nindent 4}}
   {{ range .Values.additionalConfigs }}
   {{.name }}: |

--- a/cloudprober/templates/configmap.yaml
+++ b/cloudprober/templates/configmap.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ include "cloudprober.fullname" . }}
 data:
-  cloudprober.{{- .Values.configFormat }}: |
+  {{- .Values.configFileName | default "cloudprober" }}.{{- .Values.configFormat }}: |
   {{- .Values.config | nindent 4}}
   {{ range .Values.additionalConfigs }}
   {{.name }}: |

--- a/cloudprober/templates/deployment.yaml
+++ b/cloudprober/templates/deployment.yaml
@@ -48,18 +48,10 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          args:
-            {{ if .Values.cloudprober_args }}
-            {{ with .Values.cloudprober_args }}
-              - {{- toYaml . | nindent 12 }}
-            {{ else }}
-              - "--config_file"
-              - "{{ .Values.cloudprober_cfg_path | default "/cfg"  }}/cloudprober.{{- .Values.configFormat -}}"
-            {{- end }}
-            {{- end }}
+          args: ['--config_file', '/cfg/{{- .Values.configFileName | default "cloudprober" -}}.{{- .Values.configFormat -}}', '--logtostderr']
           volumeMounts:
             - name: cloudprober-config
-              mountPath: {{ .Values.cloudprober_cfg_path | default "/cfg"  }}
+              mountPath: /cfg
             {{- range .Values.extraConfigmapMounts }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}

--- a/cloudprober/templates/deployment.yaml
+++ b/cloudprober/templates/deployment.yaml
@@ -48,10 +48,19 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          args: ['--config_file', '/cfg/cloudprober.{{- .Values.configFormat -}}', '--logtostderr']
+          args:
+            - "--logtostderr"          
+            {{ if .Values.cloudprober_args }}
+            {{ with .Values.cloudprober_args }}
+              - {{- toYaml . | nindent 12 }}
+            {{ else }}
+              - "--config_file"
+              - "{{ .Values.cloudprober_cfg_path | default "/cfg"  }}/cloudprober.{{- .Values.configFormat -}}"
+            {{- end }}
+            {{- end }}
           volumeMounts:
             - name: cloudprober-config
-              mountPath: /cfg
+              mountPath: {{ .Values.cloudprober_cfg_path | default "/cfg"  }}
             {{- range .Values.extraConfigmapMounts }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}

--- a/cloudprober/templates/deployment.yaml
+++ b/cloudprober/templates/deployment.yaml
@@ -49,7 +49,6 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            - "--logtostderr"          
             {{ if .Values.cloudprober_args }}
             {{ with .Values.cloudprober_args }}
               - {{- toYaml . | nindent 12 }}

--- a/cloudprober/templates/deployment.yaml
+++ b/cloudprober/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          args: ['--config_file', '/cfg/{{- .Values.configFileName | default "cloudprober" -}}.{{- .Values.configFormat -}}', '--logtostderr']
+          args: ['--config_file', '/cfg/{{- .Values.configFileName | default "cloudprober" -}}.{{- .Values.configFormat -}}']
           volumeMounts:
             - name: cloudprober-config
               mountPath: /cfg

--- a/cloudprober/templates/deployment.yaml
+++ b/cloudprober/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          args: ['--config_file', '/cfg/{{- .Values.configFileName | default "cloudprober" -}}.{{- .Values.configFormat -}}']
+          args: ['--config_file', '/cfg/{{- .Values.configFileName -}}.{{- .Values.configFormat -}}']
           volumeMounts:
             - name: cloudprober-config
               mountPath: /cfg

--- a/cloudprober/values.yaml
+++ b/cloudprober/values.yaml
@@ -22,8 +22,8 @@ configMap:
   name: ''
   create: true
 
-# The default config filename is 'cloudprober'. If managing the configMap outside of helm,
-# you may want to use a more specific filename instead, which can be set via configFileName
+# You can override the default config filename using the following field. It's
+# typically useful if you're managing the configMap outside of helm.
 configFileName: 'cloudprober'
 # The config file suffix; suffixes that provide different parsing are:
 # "json", "yaml", "yml"

--- a/cloudprober/values.yaml
+++ b/cloudprober/values.yaml
@@ -16,11 +16,14 @@ image:
 # an existing configMap is used.
 # One caveat with managing config map outside of helm charts is that you'll
 # need to manage the deployment restart yourself after updating the config
-# map.
+# map. You may also want to set the value of configFileName
 configMap:
   name: ''
   create: true
 
+# The default config filename is 'cloudprober'. If managing the configMap outside of helm,
+# you may want to use a more specific filename instead, which can be set via configFileName
+configFileName: 'cloudprober'
 # The config file suffix; suffixes that provide different parsing are:
 # "json", "yaml", "yml"
 configFormat: 'cfg'

--- a/cloudprober/values.yaml
+++ b/cloudprober/values.yaml
@@ -16,7 +16,8 @@ image:
 # an existing configMap is used.
 # One caveat with managing config map outside of helm charts is that you'll
 # need to manage the deployment restart yourself after updating the config
-# map. You may also want to set the value of configFileName
+# map. If you're managing the configMap outside of helm and config file name
+# is different, you should set the value of configFileName as well.
 configMap:
   name: ''
   create: true


### PR DESCRIPTION
* Add templating to allow users to define their own command line arguments, with reasonable defaults if no customisation is
  defined

* Add templating to allow users to control the mount path for the configMap

