### PR TITLE
cloudprober: fix configmap template

### DIFF
--- a/cloudprober/templates/configmap.yaml
+++ b/cloudprober/templates/configmap.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ include "cloudprober.fullname" . }}
 data:
-  {{- .Values.configFileName }}.{{- .Values.configFormat }}: |
+  {{ .Values.configFileName }}.{{- .Values.configFormat }}: |
   {{- .Values.config | nindent 4}}
   {{ range .Values.additionalConfigs }}
   {{.name }}: |


### PR DESCRIPTION
Whitespace is deleted, so an invalid ConfigMap is generated:

Before: 

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: release-name-cloudprober
data:cloudprober.cfg: |
    surfacer {
      type: PROMETHEUS
    }
```

After:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: release-name-cloudprober
data:
  cloudprober.cfg: |
    surfacer {
      type: PROMETHEUS
    }
```