### PR TITLE
Add extraSecretMounts to Helm template

### DIFF
--- a/cloudprober/templates/deployment.yaml
+++ b/cloudprober/templates/deployment.yaml
@@ -49,7 +49,6 @@ spec:
             defaultMode: {{ .defaultMode | default 400 }}
             {{- with .items }}
             items:
-
               {{- toYaml . | nindent 14 }}
           {{- end }}
         {{- end }}

--- a/cloudprober/templates/deployment.yaml
+++ b/cloudprober/templates/deployment.yaml
@@ -42,6 +42,17 @@ spec:
               {{- toYaml . | nindent 14 }}
             {{- end }}
         {{- end }}
+        {{- range .Values.extraSecretMounts }}
+        - name: {{ .name }}
+          secret:
+            secretName: {{ .secretName | default .name }}
+            defaultMode: {{ .defaultMode | default 400 }}
+            {{- with .items }}
+            items:
+
+              {{- toYaml . | nindent 14 }}
+          {{- end }}
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -68,6 +79,14 @@ spec:
               {{- if .readOnly }}
               readOnly: {{ .readOnly }}
               {{- end }}
+            {{- end }}
+            {{- range .Values.extraSecretMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              {{- if .subPath }}
+              subPath: {{ .subPath }}
+              {{- end }}
+            # Assume that secrets are readOnly and we should not change that.
             {{- end }}
           ports:
             - name: http

--- a/cloudprober/values.yaml
+++ b/cloudprober/values.yaml
@@ -170,8 +170,18 @@ extraConfigmapMounts:
   # - name: certs-configmap
   #   mountPath: /certs/ssl/
   #   subPath: certificates.crt # (optional)
-  #   configMap: certs-configmap
+  #   configMap: certs-configmap # (optional, defaults to name)
   #   readOnly: true
+  #   items: []
+
+extraSecretMounts:
+  []
+#   - name: additional-probe-secrets
+#     mountPath: /var/run/probe/secret
+#     subPath: probe.key # (optional)
+#     secretName: probe-secret # (optional, defaults to name)
+#     defaultMode: 400 # (optional, defaults to 400)
+#     items: []
 
 # Extra containers. We can use these containers to run helper services like
 # cypress-server to run UI tests.


### PR DESCRIPTION
Fixes: https://github.com/cloudprober/helm-charts/issues/42

Adds the extraSecretMounts to the Helm template. No safety rails in terms of making sure the mounts don't overlap, but keeps the template simple.