### PR TITLE
Allow setting file permissions when mounting from a configmap

### DIFF
--- a/cloudprober/templates/deployment.yaml
+++ b/cloudprober/templates/deployment.yaml
@@ -37,6 +37,7 @@ spec:
         - name: {{ .name }}
           configMap:
             name: {{ .configMap | default .name }}
+            defaultMode: {{ .defaultMode | default 400 }}
             {{- with .items }}
             items:
               {{- toYaml . | nindent 14 }}

--- a/cloudprober/values.yaml
+++ b/cloudprober/values.yaml
@@ -172,6 +172,7 @@ extraConfigmapMounts:
   #   subPath: certificates.crt # (optional)
   #   configMap: certs-configmap # (optional, defaults to name)
   #   readOnly: true
+  #   defaultMode: 400 # (optional, defaults to 400)
   #   items: []
 
 extraSecretMounts:


### PR DESCRIPTION
I would like to use a shell script for the cmd option on the oauth config as listed [here](https://cloudprober.org/docs/how-to/oauth/#oauth-configuration). The easiest way to do this without building a custom image is to mount the shell script from a configmap but when mounted, it is not executable. This will allow the user make that file executable.