### PR TITLE
feat: Add checksum override as a helm option

### DIFF
--- a/cloudprober/templates/deployment.yaml
+++ b/cloudprober/templates/deployment.yaml
@@ -15,7 +15,7 @@ spec:
         {{- if $.Values.podAnnotations }}
           {{- toYaml .Values.podAnnotations | nindent 8 }}
         {{- end }}
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/config: {{ .Values.checksumOverride | default (include (print $.Template.BasePath "/configmap.yaml") . | sha256sum) }}
       labels:
         {{- if $.Values.podLabels }}
           {{- toYaml .Values.podLabels | nindent 8 }}

--- a/cloudprober/values.yaml
+++ b/cloudprober/values.yaml
@@ -173,6 +173,11 @@ extraConfigmapMounts:
   #   configMap: certs-configmap
   #   readOnly: true
 
+# Override the checksum annotation to force pod restarts.
+# When empty (default), uses the ConfigMap content hash for automatic restarts on config changes.
+# Set to any unique value (e.g., current timestamp) to force a restart.
+checksumOverride: ''
+
 # Extra containers. We can use these containers to run helper services like
 # cypress-server to run UI tests.
 extraContainers: ''


### PR DESCRIPTION
If you are subcharting cloudprober, or you manage the config outside the cloudprober chart, this provides a way of still letting the deployment spec recreate if a checksum changes.