### PR TITLE
fix: ServiceMonitor selector doesn't match Service labels

### DIFF
--- a/cloudprober/templates/servicemonitor.yaml
+++ b/cloudprober/templates/servicemonitor.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/instance: {{ include "cloudprober.fullname" . }}
+      {{- include "cloudprober.selectorLabels" . | nindent 6 }}
   namespaceSelector:
     matchNames: 
     - {{ .Release.Namespace }}


### PR DESCRIPTION
## Problem

The ServiceMonitor selector uses `cloudprober.fullname` for `app.kubernetes.io/instance`:

```yaml
selector:
  matchLabels:
    app.kubernetes.io/instance: {{ include "cloudprober.fullname" . }}
```

But the Service (and Pod) labels use `cloudprober.selectorLabels`, which sets `app.kubernetes.io/instance` to `{{ .Release.Name }}`.

When cloudprober is deployed as a **subchart**, `fullname` becomes `<release>-cloudprober` while `Release.Name` stays as just `<release>`. So the selector and Service labels diverge, so Prometheus/VictoriaMetrics never discovers the scrape target and no metrics are collected.

## Fix

Use `cloudprober.selectorLabels` in the ServiceMonitor selector, matching the labels actually present on the Service.

(N.B. Claude has generated the PR, but I think this is a reasonable approach) 