### PR TITLE
Bump chart version to 1.0.16

### DIFF
--- a/cloudprober/Chart.yaml
+++ b/cloudprober/Chart.yaml
@@ -15,7 +15,7 @@ description: A Helm chart for Cloudprober
 type: application
 
 # Note that final chart is computed by adding up this version and appVersion.
-version: 1.0.15
+version: 1.0.16
 
 # Cloudprober release version
 # This is automatically updated when there is a new Cloudprober release.


### PR DESCRIPTION
## Summary
- Bump chart version from 1.0.15 to 1.0.16 to release the ServiceMonitor selector fix (#49).

## Test plan
- [ ] Verify the new chart version is published correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)