### PR TITLE
feat: support external probes via initContainer binary copy

### DIFF
--- a/cloudprober/Chart.yaml
+++ b/cloudprober/Chart.yaml
@@ -15,7 +15,7 @@ description: A Helm chart for Cloudprober
 type: application
 
 # Note that final chart is computed by adding up this version and appVersion.
-version: 1.0.16
+version: 1.0.17
 
 # Cloudprober release version
 # This is automatically updated when there is a new Cloudprober release.

--- a/cloudprober/templates/deployment.yaml
+++ b/cloudprober/templates/deployment.yaml
@@ -1,3 +1,5 @@
+{{- $useExternalProberImage := .Values.externalProberImage.repository -}}
+{{- $cloudproberImage := printf "%s:%s" .Values.image.repository (.Values.image.tag | default .Chart.AppVersion) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -34,6 +36,10 @@ spec:
         - name: cloudprober-config
           configMap:
             name: {{ include "cloudprober.config-map.name" . }}
+        {{- if $useExternalProberImage }}
+        - name: cloudprober-bin
+          emptyDir: {}
+        {{- end }}
         {{- range .Values.extraConfigmapMounts }}
         - name: {{ .name }}
           configMap:
@@ -54,12 +60,28 @@ spec:
               {{- toYaml . | nindent 14 }}
           {{- end }}
         {{- end }}
+      {{- if $useExternalProberImage }}
+      initContainers:
+        - name: cloudprober-init
+          image: {{ $cloudproberImage | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["cp", "/cloudprober", "/cloudprober-bin/cloudprober"]
+          volumeMounts:
+            - name: cloudprober-bin
+              mountPath: /cloudprober-bin
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          {{- if $useExternalProberImage }}
+          image: "{{ .Values.externalProberImage.repository }}:{{ .Values.externalProberImage.tag }}"
+          imagePullPolicy: {{ .Values.externalProberImage.pullPolicy }}
+          command: ["/cloudprober-bin/cloudprober"]
+          {{- else }}
+          image: {{ $cloudproberImage | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- end }}
           args:
             - "--config_file"
             - "/cfg/{{- .Values.configFileName -}}.{{- .Values.configFormat -}}"
@@ -71,6 +93,11 @@ spec:
           volumeMounts:
             - name: cloudprober-config
               mountPath: /cfg
+            {{- if $useExternalProberImage }}
+            - name: cloudprober-bin
+              mountPath: /cloudprober-bin
+              readOnly: true
+            {{- end }}
             {{- range .Values.extraConfigmapMounts }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}

--- a/cloudprober/values.yaml
+++ b/cloudprober/values.yaml
@@ -10,6 +10,29 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: null
 
+# externalProberImage: when set, enables running an external probe (see
+# https://cloudprober.org/docs/how-to/external-probe/) that requires extra
+# dependencies (e.g. redis-cli, mysql-client) without building a custom image
+# that bundles both cloudprober and the dependencies.
+#
+# How it works:
+#  - The cloudprober container runs as an initContainer that copies the
+#    cloudprober binary to a shared emptyDir volume.
+#  - The externalProberImage is run as the main container and executes the
+#    cloudprober binary from the shared volume.
+#
+# The external prober image only needs the extra binaries your external probe
+# invokes; it does not need to include cloudprober itself.
+#
+# Example:
+# externalProberImage:
+#   repository: myregistry/redis-prober
+#   tag: "1.0.0"
+externalProberImage:
+  repository: ''
+  tag: ''
+  pullPolicy: IfNotPresent
+
 # extraArgs to add args to the cloudprober container in order to add cloudprober flags
 # extraArgs:
 #  - "--cloud_metadata=none"


### PR DESCRIPTION
## Summary
- Adds a new `externalProberImage` value to the chart. When set, cloudprober is run as an initContainer that copies its binary to a shared `emptyDir` volume, and the user-supplied external prober image runs as the main container, invoking the copied cloudprober binary.
- Lets users run [external probes](https://cloudprober.org/docs/how-to/external-probe/) that require extra dependencies (e.g. `redis-cli`, `mysql-client`) without having to build a custom image that bundles cloudprober itself.
- Default behavior is unchanged when `externalProberImage.repository` is empty — the rendered deployment is byte-identical to before.

Fixes #43.

## Example

```yaml
externalProberImage:
  repository: myregistry/redis-prober
  tag: "1.0.0"
```

## Test plan
- [x] `helm lint ./cloudprober` passes
- [x] `helm template` with default values produces output byte-identical to pre-change
- [x] `helm template` with `externalProberImage` set renders an initContainer that copies `/cloudprober` to a shared volume, and a main container using the external image with `command: ["/cloudprober-bin/cloudprober"]`
- [x] `extraArgs`, `env`, `extraSecretMounts`, and `extraConfigmapMounts` still compose correctly in external prober mode
- [ ] End-to-end test on a live cluster with a real external probe (e.g. redis)

🤖 Generated with [Claude Code](https://claude.com/claude-code)