### PR TITLE
ci: publish helm chart as OCI artifact to ghcr.io

### DIFF
--- a/.github/workflows/lint_and_release.yml
+++ b/.github/workflows/lint_and_release.yml
@@ -64,6 +64,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [paths-filter, helm-lint]
     if: needs.paths-filter.outputs.charts_yaml_changing == 'true'
+    permissions:
+      contents: write
+      packages: write
     steps:
       - name: Check out repo hosting code
         uses: actions/checkout@v3
@@ -127,3 +130,9 @@ jobs:
           git config user.email "manugarg@gmail.com"
           git commit -m "[automated] Update helm charts repo" || exit 0
           git push
+
+      - name: Push chart to GHCR (OCI)
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags')
+        run: |-
+          helm registry login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
+          helm push repo/packages/cloudprober-${CHART_VERSION}.tgz oci://ghcr.io/cloudprober/charts

--- a/cloudprober/README.md
+++ b/cloudprober/README.md
@@ -10,10 +10,12 @@ https://github.com/cloudprober/helm-charts/tree/main/cloudprober
 
 ## To install:
 
+The chart is published as an OCI artifact to GitHub Container Registry.
+Helm 3.8+ is required.
+
 ```
-helm repo add cloudprober https://helm.cloudprober.org/
-helm repo update
-helm install cloudprober cloudprober/cloudprober -n cloudprober --create-namespace
+helm install cloudprober oci://ghcr.io/cloudprober/charts/cloudprober \
+    -n cloudprober --create-namespace
 ```
 
 ## To add/update the Cloudprober config
@@ -21,14 +23,27 @@ helm install cloudprober cloudprober/cloudprober -n cloudprober --create-namespa
 You can either add config directly in the `values.yaml`, or you can provide config on the command line through the `--set-file` flag.
 
 ```
-helm upgrade --install cloudprober cloudprober/cloudprober \
+helm upgrade --install cloudprober oci://ghcr.io/cloudprober/charts/cloudprober \
     --set-file config=~/monitoring/config/cloudprober.cfg -n cloudprober
 ```
 
 To specify additional configs, for including in the main config file for example:
 
 ```
-helm upgrade install cloudprober cloudprober/cloudprober -n cloudprober --set-file config=cloudprober.cfg \
+helm upgrade --install cloudprober oci://ghcr.io/cloudprober/charts/cloudprober \
+  -n cloudprober --set-file config=cloudprober.cfg \
   --set additionalConfigs[0].name=team1.cfg --set-file additionalConfigs[0].value=cloudprober.d/team1.cfg \
   --set additionalConfigs[1].name=team2.cfg --set-file additionalConfigs[1].value=cloudprober.d/team2.cfg
+```
+
+## Legacy: classic Helm repository (deprecated)
+
+The chart is also still published to the classic Helm repo at
+`https://helm.cloudprober.org/` for backwards compatibility. New users should
+prefer the OCI form above; this path may be retired in a future release.
+
+```
+helm repo add cloudprober https://helm.cloudprober.org/
+helm repo update
+helm install cloudprober cloudprober/cloudprober -n cloudprober --create-namespace
 ```


### PR DESCRIPTION
## Summary
- Adds OCI publishing of the cloudprober chart to `ghcr.io/cloudprober/charts/cloudprober` alongside the existing classic gh-pages repo, so users can install with `helm install oci://ghcr.io/cloudprober/charts/cloudprober` (Helm 3.8+).
- The new `Push chart to GHCR (OCI)` step in the `chart-release` job logs in with `GITHUB_TOKEN` and runs `helm push` on the already-built `cloudprober-${CHART_VERSION}.tgz`. Gated on `main`/tags, same as the existing gh-pages push.
- README now recommends the OCI install form; the classic `helm repo add https://helm.cloudprober.org/` instructions are kept under a "Legacy" section so existing users aren't broken.

## Why
OCI is the recommended Helm distribution format (Helm 3.8+ GA). Publishing to GHCR puts the chart next to the cloudprober container image (one auth surface, simpler discovery) and removes the gh-pages / index.yaml churn for new users. The classic repo is kept publishing for now and can be retired in a follow-up once users have migrated.

## Post-merge one-time setup
After the first successful run on `main`, the `cloudprober/charts/cloudprober` GHCR package needs to be made **public** and linked to this repo in the org package settings; otherwise unauthenticated `helm pull` will fail.

## Test plan
- [ ] PR run: `helm-lint` + chart-testing jobs pass; OCI push step is skipped on PRs (gated on main/tags)
- [ ] Post-merge run: `chart-release` job succeeds and the `Push chart to GHCR (OCI)` step logs `Pushed: ghcr.io/cloudprober/charts/cloudprober:<version>`
- [ ] After making the package public, `helm show chart oci://ghcr.io/cloudprober/charts/cloudprober --version <version>` works from an unauthenticated shell
- [ ] Classic path still works: `helm repo update cloudprober && helm search repo cloudprober/cloudprober` lists the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)