### PR TITLE
Added service annotations to values, added services to expose built-in servers

### DIFF
--- a/cloudprober/templates/configmap.yaml
+++ b/cloudprober/templates/configmap.yaml
@@ -5,7 +5,28 @@ metadata:
   name: {{ include "cloudprober.fullname" . }}
 data:
   {{ .Values.configFileName }}.{{- .Values.configFormat }}: |
-  {{- .Values.config | nindent 4}}
+  {{- .Values.config | nindent 4 }}
+  {{- if eq .Values.configFormat "cfg" }}
+  {{- if .Values.builtinServers.http.enabled }}
+
+    server {
+      type: HTTP
+      http_server {
+        port: {{ .Values.builtinServers.http.port }}
+      }
+    }
+  {{- end }}
+  {{- if .Values.builtinServers.udp.enabled }}
+
+    server {
+      type: UDP
+      udp_server {
+        port: {{ .Values.builtinServers.udp.port }}
+        type: {{ .Values.builtinServers.udp.mode }}
+      }
+    }
+  {{- end }}
+  {{- end }}
   {{ range .Values.additionalConfigs }}
   {{.name }}: |
   {{- .value | nindent 4}}

--- a/cloudprober/templates/deployment.yaml
+++ b/cloudprober/templates/deployment.yaml
@@ -120,6 +120,16 @@ spec:
             - name: http
               containerPort: 9313
               protocol: TCP
+            {{- if .Values.builtinServers.http.enabled }}
+            - name: builtin-http
+              containerPort: {{ .Values.builtinServers.http.port }}
+              protocol: TCP
+            {{- end }}
+            {{- if .Values.builtinServers.udp.enabled }}
+            - name: builtin-udp
+              containerPort: {{ .Values.builtinServers.udp.port }}
+              protocol: UDP
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /health

--- a/cloudprober/templates/service-builtin-http.yaml
+++ b/cloudprober/templates/service-builtin-http.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.builtinServers.http.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cloudprober.fullname" . }}-builtin-http
+  labels:
+    {{- include "cloudprober.labels" . | nindent 4 }}
+  {{- with .Values.builtinServers.http.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.builtinServers.http.service.type }}
+  ports:
+    - port: {{ .Values.builtinServers.http.service.port }}
+      targetPort: builtin-http
+      protocol: TCP
+      name: builtin-http
+  selector:
+    {{- include "cloudprober.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/cloudprober/templates/service-builtin-udp.yaml
+++ b/cloudprober/templates/service-builtin-udp.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.builtinServers.udp.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cloudprober.fullname" . }}-builtin-udp
+  labels:
+    {{- include "cloudprober.labels" . | nindent 4 }}
+  {{- with .Values.builtinServers.udp.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.builtinServers.udp.service.type }}
+  ports:
+    - port: {{ .Values.builtinServers.udp.service.port }}
+      targetPort: builtin-udp
+      protocol: UDP
+      name: builtin-udp
+  selector:
+    {{- include "cloudprober.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/cloudprober/templates/service.yaml
+++ b/cloudprober/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "cloudprober.fullname" . }}
   labels:
     {{- include "cloudprober.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/cloudprober/values.yaml
+++ b/cloudprober/values.yaml
@@ -143,6 +143,35 @@ shareProcessNamespace: true
 service:
   type: ClusterIP
   port: 8080
+  annotations: {}
+
+# Built-in cloudprober servers (https://cloudprober.org/docs/how-to/built-in-servers/).
+# When enabled, the chart appends a corresponding `server { ... }` block to
+# the rendered cloudprober config, opens the container port on the pod, and
+# creates a dedicated Kubernetes Service that exposes it.
+#
+# Note: automatic config injection only works with the default `cfg`
+# (protobuf text) configFormat. If you are using `yaml`/`json`, declare the
+# server blocks manually in `config` and just use this section to expose
+# the ports.
+builtinServers:
+  http:
+    enabled: false
+    port: 3141
+    service:
+      type: ClusterIP
+      port: 3141
+      annotations: {}
+  udp:
+    enabled: false
+    port: 31415
+    # UDP server mode: ECHO bounces packets back to the sender, DISCARD drops
+    # them silently.
+    mode: ECHO
+    service:
+      type: ClusterIP
+      port: 31415
+      annotations: {}
 
 serviceMonitor:
   enabled: true


### PR DESCRIPTION
- added `.service.annotations` option to specify annotations for a service (my case - Cilium global services)
- added `builtinServers` section to easily provision built-in servers via `values.yaml` file

Thanks in advance!