### PR TITLE
feat: add service monitor interval selector

### DIFF
--- a/cloudprober/Chart.yaml
+++ b/cloudprober/Chart.yaml
@@ -15,7 +15,7 @@ description: A Helm chart for Cloudprober
 type: application
 
 # Note that final chart is computed by adding up this version and appVersion.
-version: 1.0.17
+version: 1.0.18
 
 # Cloudprober release version
 # This is automatically updated when there is a new Cloudprober release.

--- a/cloudprober/templates/servicemonitor.yaml
+++ b/cloudprober/templates/servicemonitor.yaml
@@ -11,6 +11,6 @@ spec:
     matchNames: 
     - {{ .Release.Namespace }}
   endpoints:
-  - interval: 10s
+  - interval: {{ .Values.serviceMonitor.interval }}
     path: /metrics
 {{- end }}

--- a/cloudprober/values.yaml
+++ b/cloudprober/values.yaml
@@ -146,6 +146,7 @@ service:
 
 serviceMonitor:
   enabled: true
+  interval: 1m
 
 ingress:
   enabled: false


### PR DESCRIPTION
Resolves [issue 54](https://github.com/cloudprober/helm-charts/issues/54)

Adds a new serviceMonitor interval key that allows defining custom values.

Also defines a new 1m default, which is the default Prometheus scrape rate.